### PR TITLE
Fix duplicate dependancies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1"
-include_dir = "0.2"
+include_dir = "0.6"
 serde =  { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 yaml-rust = "0.4"
@@ -21,8 +21,8 @@ regex = "1"
 lazy_static = "1.3"
 itertools = "0.8"
 linked-hash-map = "0.5"
-strum = "0.15"
-strum_macros = "0.15"
+strum = "0.20"
+strum_macros = "0.20"
 enum-map = { version = "0.5", features = ["serde"] }
 env_logger = "0.6"
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
-const MULTILINE_TEMPLATE_NAME: &'static str = "multi_line";
-const SHORT_ADDR_TEMPLATE_NAME: &'static str = "short_addr";
+const MULTILINE_TEMPLATE_NAME: &str = "multi_line";
+const SHORT_ADDR_TEMPLATE_NAME: &str = "short_addr";
 
 /// Represents a Regex and the value to replace the regex matches with
 #[derive(Debug, Clone)]
@@ -79,7 +79,7 @@ pub(crate) struct Template {
 // it's not very elegant, but it works to only find the line with the housenumber
 fn compute_short_addr_template(place_template: &str) -> Option<String> {
     place_template
-        .split("\n")
+        .split('\n')
         .find(|l| l.contains("house_number"))
         .map(|l| l.trim().to_owned())
 }
@@ -247,7 +247,7 @@ impl Formatter {
         let rules = country_code
             .as_ref()
             .and_then(|c| self.templates.rules_by_country.get(c))
-            .unwrap_or_else(|| &self.templates.fallback_rules);
+            .unwrap_or(&self.templates.fallback_rules);
 
         self.preformat(&rules, &mut addr);
 
@@ -361,7 +361,7 @@ impl Formatter {
                     self.templates
                         .fallback_templates_by_country
                         .get(&c)
-                        .or_else(|| Some(&self.templates.fallback_template))
+                        .or(Some(&self.templates.fallback_template))
                 } else {
                     self.templates.templates_by_country.get(&c)
                 }
@@ -438,7 +438,7 @@ impl PlaceBuilder {
         let mut place = Place::default();
         let mut unknown = HashMap::<String, String>::new();
         for (k, v) in values.into_iter() {
-            let component = Component::from_str(k).ok();;
+            let component = Component::from_str(k).ok();
             if let Some(component) = component {
                 place[component] = Some(v);
             } else {
@@ -504,7 +504,6 @@ fn sanity_clean_place(addr: &mut Place) {
 }
 
 fn cleanup_rendered(text: &str, rules: &Rules) -> String {
-    use itertools::Itertools;
     lazy_static::lazy_static! {
         static ref REPLACEMENTS:  [(Regex, &'static str); 12]= [
             (RegexBuilder::new(r"[},\s]+$").multi_line(true).build().unwrap(), ""),

--- a/src/handlebar_helper.rs
+++ b/src/handlebar_helper.rs
@@ -14,7 +14,7 @@ impl HelperDef for FirstNonNullHelper {
         r: &'reg Handlebars,
         ctx: &Context,
         rc: &mut RenderContext<'reg>,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> HelperResult {
         let tpl = h
             .template()
@@ -26,7 +26,7 @@ impl HelperDef for FirstNonNullHelper {
             .split("||")
             .map(|s| s.trim())
             .find(|v| !v.is_empty())
-            .unwrap_or_else(|| "");
+            .unwrap_or("");
 
         out.write(&value)?;
         Ok(())

--- a/src/read_configuration.rs
+++ b/src/read_configuration.rs
@@ -56,10 +56,12 @@ pub fn read_configuration() -> Formatter {
                     })
                     .collect();
 
-                let template = build_template(&v["address_template"]).expect(&format!(
-                    "no address_template found for country {}",
-                    country_code
-                ));
+                let template = build_template(&v["address_template"]).unwrap_or_else(|err| {
+                    panic!(
+                        "Err {}: no address_template found for country {}",
+                        err, country_code
+                    )
+                });
                 let rules = Rules {
                     replace: replace_rules,
                     postformat_replace: post_format_replace_rules,
@@ -94,8 +96,8 @@ pub fn read_configuration() -> Formatter {
 
         let mut new_rules = rules_by_country
             .get(&parent_country_code)
-            .map(|r| r.clone())
-            .unwrap_or_else(|| Rules::default());
+            .cloned()
+            .unwrap_or_else(Rules::default);
         new_rules.change_country_code = Some(parent_country_code.as_str().to_owned());
         new_rules.change_country = template["change_country"].as_str().map(|s| s.to_string());
         new_rules.add_component = add_component;
@@ -161,12 +163,12 @@ pub fn read_place_builder_configuration() -> PlaceBuilder {
     for c in &raw_components {
         if let Some(aliases) = c["aliases"].as_vec() {
             let name = c["name"].as_str().unwrap();
-            let component =
-                Component::from_str(name).expect(&format!("{} is not a valid component", name));
+            let component = Component::from_str(name)
+                .unwrap_or_else(|err| panic!("Err {}: {} is not a valid component", err, name));
             for a in aliases {
                 component_aliases
                     .entry(component)
-                    .or_insert_with(|| vec![])
+                    .or_insert_with(Vec::new)
                     .push(a.as_str().unwrap().to_string());
             }
         }
@@ -197,10 +199,12 @@ fn read_replace(yaml_rules: &yaml_rust::Yaml) -> Vec<ReplaceRule> {
                         // it's a replace on only one component
                         // the rules is written 'component=<string_to_replace'
                         let parts = first_val.split('=').collect::<Vec<_>>();
-                        let component = Component::from_str(parts[0]).expect(&format!(
-                            "in replace '{}' is not a valid component",
-                            parts[0]
-                        ));
+                        let component = Component::from_str(parts[0]).unwrap_or_else(|err| {
+                            panic!(
+                                "Err {}: in replace '{}' is not a valid component",
+                                err, parts[0]
+                            )
+                        });
                         ReplaceRule::Component((
                             component,
                             Replacement {
@@ -230,5 +234,5 @@ fn read_replace(yaml_rules: &yaml_rust::Yaml) -> Vec<ReplaceRule> {
                 })
                 .collect()
         })
-        .unwrap_or_else(|| vec![])
+        .unwrap_or_else(Vec::new)
 }

--- a/tests/opencage_tests.rs
+++ b/tests/opencage_tests.rs
@@ -1,6 +1,6 @@
 use address_formatter::{Formatter, Place, PlaceBuilder};
 use failure::{format_err, Error};
-use include_dir::{include_dir, include_dir_impl};
+use include_dir::include_dir;
 use yaml_rust::{Yaml, YamlLoader};
 
 #[test]

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -81,7 +81,7 @@ pub fn address_builder() {
         ("state", "French Polynesia"),
     ];
 
-    let addr = addr_builder.build_place(data.into_iter().map(|(k, v)| (k.clone(), v.to_string())));
+    let addr = addr_builder.build_place(data.iter().map(|(k, v)| (*k, v.to_string())));
 
     assert_eq!(
         formatter.format(addr).unwrap(),


### PR DESCRIPTION
I just updated the crates that relied on `quote`/`syn`/... in order to deduplicate their dependencies (which previously appeared as different versions). Now, `cargo tree -d` has an empty output. This should help a bit with compilation time since we now only need to compile 93 crates, instead of 109 (plus, `proc_macro` & cie. are known to be quite expensive to compile). 

I think we could benefit a lot by doing the same kind of thing in mimirsbrunn but it seems like hard work for now since it would require to update actix to a recent version.


(I also fixed most clippy warnings while I was here)