### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "address-formatter"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["antoine-de <antoine.desbordes@gmail.com>"]
 edition = "2021"
 license = "AGPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ keywords = ["address", "i18n", "geocoder", "mimirsbrunn", "navitia"]
 readme = "README.md"
 
 [dependencies]
-failure = "0.1"
-include_dir = "0.7"
+anyhow = "1"
 serde =  { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 yaml-rust = "0.4"
@@ -24,7 +23,8 @@ linked-hash-map = "0.5"
 strum = "0.23"
 strum_macros = "0.23"
 enum-map = { version = "1", features = ["serde"] }
-env_logger = "0.9"
 
 [dev-dependencies]
+env_logger = "0.9"
+include_dir = "0.7"
 maplit = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde =  { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 yaml-rust = "0.4"
 log = "0.4"
-handlebars = "2.0.0-beta.1"
+handlebars = "4"
 regex = "1"
 lazy_static = "1"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "address-formatter"
 version = "0.2.1"
 authors = ["antoine-de <antoine.desbordes@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0"
 description = "Universal international address formatter"
 repository = "https://github.com/CanalTP/address-formatter-rs"
@@ -11,20 +11,20 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1"
-include_dir = "0.2"
+include_dir = "0.7"
 serde =  { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 yaml-rust = "0.4"
 log = "0.4"
 handlebars = "2.0.0-beta.1"
 regex = "1"
-lazy_static = "1.3"
-itertools = "0.8"
+lazy_static = "1"
+itertools = "0.10"
 linked-hash-map = "0.5"
-strum = "0.15"
-strum_macros = "0.15"
-enum-map = { version = "0.5", features = ["serde"] }
-env_logger = "0.6"
+strum = "0.23"
+strum_macros = "0.23"
+enum-map = { version = "1", features = ["serde"] }
+env_logger = "0.9"
 
 [dev-dependencies]
-maplit = "1.0.1"
+maplit = "1"

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
-const MULTILINE_TEMPLATE_NAME: &'static str = "multi_line";
-const SHORT_ADDR_TEMPLATE_NAME: &'static str = "short_addr";
+const MULTILINE_TEMPLATE_NAME: &str = "multi_line";
+const SHORT_ADDR_TEMPLATE_NAME: &str = "short_addr";
 
 /// Represents a Regex and the value to replace the regex matches with
 #[derive(Debug, Clone)]
@@ -79,7 +79,7 @@ pub(crate) struct Template {
 // it's not very elegant, but it works to only find the line with the housenumber
 fn compute_short_addr_template(place_template: &str) -> Option<String> {
     place_template
-        .split("\n")
+        .split('\n')
         .find(|l| l.contains("house_number"))
         .map(|l| l.trim().to_owned())
 }
@@ -247,16 +247,16 @@ impl Formatter {
         let rules = country_code
             .as_ref()
             .and_then(|c| self.templates.rules_by_country.get(c))
-            .unwrap_or_else(|| &self.templates.fallback_rules);
+            .unwrap_or(&self.templates.fallback_rules);
 
-        self.preformat(&rules, &mut addr);
+        self.preformat(rules, &mut addr);
 
         let text = template
             .handlebar_handler
             .render(MULTILINE_TEMPLATE_NAME, &addr)
             .map_err(|e| e.context("impossible to render template"))?;
 
-        let text = cleanup_rendered(&text, &rules);
+        let text = cleanup_rendered(&text, rules);
 
         Ok(text)
     }
@@ -360,10 +360,10 @@ impl Formatter {
                     // if there is a specific one, else we get the default fallback template
                     self.templates
                         .fallback_templates_by_country
-                        .get(&c)
-                        .or_else(|| Some(&self.templates.fallback_template))
+                        .get(c)
+                        .or(Some(&self.templates.fallback_template))
                 } else {
-                    self.templates.templates_by_country.get(&c)
+                    self.templates.templates_by_country.get(c)
                 }
             })
             .unwrap_or(&self.templates.default_template)
@@ -438,7 +438,7 @@ impl PlaceBuilder {
         let mut place = Place::default();
         let mut unknown = HashMap::<String, String>::new();
         for (k, v) in values.into_iter() {
-            let component = Component::from_str(k).ok();;
+            let component = Component::from_str(k).ok();
             if let Some(component) = component {
                 place[component] = Some(v);
             } else {
@@ -504,7 +504,6 @@ fn sanity_clean_place(addr: &mut Place) {
 }
 
 fn cleanup_rendered(text: &str, rules: &Rules) -> String {
-    use itertools::Itertools;
     lazy_static::lazy_static! {
         static ref REPLACEMENTS:  [(Regex, &'static str); 12]= [
             (RegexBuilder::new(r"[},\s]+$").multi_line(true).build().unwrap(), ""),
@@ -588,7 +587,7 @@ impl ReplaceRule {
                         addr[c] = Some(
                             replace_rule
                                 .regex
-                                .replace(&v, replace_rule.replacement_value.as_str())
+                                .replace(v, replace_rule.replacement_value.as_str())
                                 .to_string(),
                         );
                     }
@@ -599,7 +598,7 @@ impl ReplaceRule {
                     addr[*c] = Some(
                         replace_rule
                             .regex
-                            .replace(&v, replace_rule.replacement_value.as_str())
+                            .replace(v, replace_rule.replacement_value.as_str())
                             .to_string(),
                     );
                 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,6 +1,5 @@
 use crate::{Component, Place};
-use failure::Fail;
-use failure::{format_err, Error};
+use anyhow::{anyhow, Context, Error};
 use itertools::Itertools;
 use regex::{Regex, RegexBuilder};
 use std::collections::HashMap;
@@ -39,7 +38,7 @@ impl FromStr for CountryCode {
                 Ok(CountryCode(s.to_uppercase()))
             }
         } else {
-            Err(format_err!(
+            Err(anyhow!(
                 "{} is not a valid ISO3166-1:alpha2 country code",
                 s,
             ))
@@ -254,7 +253,7 @@ impl Formatter {
         let text = template
             .handlebar_handler
             .render(MULTILINE_TEMPLATE_NAME, &addr)
-            .map_err(|e| e.context("impossible to render template"))?;
+            .context("impossible to render template")?;
 
         let text = cleanup_rendered(&text, rules);
 
@@ -309,7 +308,7 @@ impl Formatter {
         let text = template
             .handlebar_handler
             .render(SHORT_ADDR_TEMPLATE_NAME, &addr)
-            .map_err(|e| e.context("impossible to render short address template"))?;
+            .context("impossible to render short address template")?;
 
         let text = text.trim().to_owned();
         Ok(text)

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -70,7 +70,7 @@ pub(crate) struct NewComponent {
 #[derive(Debug, Default)]
 pub(crate) struct Template {
     /// Moustache template
-    pub handlebar_handler: handlebars::Handlebars,
+    pub handlebar_handler: handlebars::Handlebars<'static>,
     place_template: String, // used only to clone the template
 }
 
@@ -347,11 +347,7 @@ impl Formatter {
         country_code
     }
 
-    fn find_template<'a>(
-        &'a self,
-        addr: &Place,
-        country_code: &Option<CountryCode>,
-    ) -> &'a Template {
+    fn find_template(&self, addr: &Place, country_code: &Option<CountryCode>) -> &Template {
         country_code
             .as_ref()
             .and_then(|c| {

--- a/src/handlebar_helper.rs
+++ b/src/handlebar_helper.rs
@@ -8,12 +8,12 @@ use handlebars::{
 pub struct FirstNonNullHelper;
 
 impl HelperDef for FirstNonNullHelper {
-    fn call<'reg: 'rc, 'rc>(
+    fn call<'reg: 'rc, 'rc, 'a>(
         &self,
         h: &Helper<'reg, 'rc>,
         r: &'reg Handlebars,
-        ctx: &Context,
-        rc: &mut RenderContext<'reg>,
+        ctx: &'a Context,
+        rc: &mut RenderContext<'reg, 'a>,
         out: &mut dyn Output,
     ) -> HelperResult {
         let tpl = h
@@ -33,7 +33,7 @@ impl HelperDef for FirstNonNullHelper {
     }
 }
 
-pub fn new_template_engine() -> handlebars::Handlebars {
+pub fn new_template_engine() -> handlebars::Handlebars<'static> {
     let mut template_engine = handlebars::Handlebars::new();
 
     // we add our custom helper, 'first'

--- a/src/handlebar_helper.rs
+++ b/src/handlebar_helper.rs
@@ -14,7 +14,7 @@ impl HelperDef for FirstNonNullHelper {
         r: &'reg Handlebars,
         ctx: &Context,
         rc: &mut RenderContext<'reg>,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> HelperResult {
         let tpl = h
             .template()
@@ -26,9 +26,9 @@ impl HelperDef for FirstNonNullHelper {
             .split("||")
             .map(|s| s.trim())
             .find(|v| !v.is_empty())
-            .unwrap_or_else(|| "");
+            .unwrap_or("");
 
-        out.write(&value)?;
+        out.write(value)?;
         Ok(())
     }
 }

--- a/src/read_configuration.rs
+++ b/src/read_configuration.rs
@@ -4,19 +4,26 @@ use crate::formatter::{
 };
 use crate::Component;
 use failure::{format_err, Error};
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::str::FromStr;
+
+lazy_static! {
+    static ref RAW_TEMPLATES: Vec<yaml_rust::Yaml> = {
+        let raw_yaml = include_str!("../address-formatting/conf/countries/worldwide.yaml");
+
+        yaml_rust::YamlLoader::load_from_str(raw_yaml)
+            .expect("impossible to read worldwide.yaml file")
+    };
+}
 
 pub fn read_configuration() -> Formatter {
     // read all the opencage configuration
     // let opencage_dir = include_dir!("./address-formatting/conf");
-    let templates_file = include_str!("../address-formatting/conf/countries/worldwide.yaml");
-
-    let raw_templates = yaml_rust::YamlLoader::load_from_str(templates_file)
-        .expect("impossible to read worldwide.yaml file");
-    let default_template = build_template(&raw_templates[0]["default"]["address_template"])
+    let default_template = build_template(&RAW_TEMPLATES[0]["default"]["address_template"])
         .expect("no default address_template provided");
-    let fallback_template = build_template(&raw_templates[0]["default"]["fallback_template"])
+
+    let fallback_template = build_template(&RAW_TEMPLATES[0]["default"]["fallback_template"])
         .expect("no fallback address_template provided");
 
     // some countries uses the same rules as other countries (with some slight changes)
@@ -26,7 +33,7 @@ pub fn read_configuration() -> Formatter {
 
     let mut fallback_templates_by_country = HashMap::new();
     let mut rules_by_country = HashMap::new();
-    let mut templates_by_country: HashMap<CountryCode, Template> = raw_templates[0]
+    let mut templates_by_country: HashMap<CountryCode, Template> = RAW_TEMPLATES[0]
         .as_hash()
         .unwrap()
         .iter()

--- a/src/read_configuration.rs
+++ b/src/read_configuration.rs
@@ -3,7 +3,7 @@ use crate::formatter::{
     Templates,
 };
 use crate::Component;
-use failure::{format_err, Error};
+use anyhow::{anyhow, Error};
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -187,7 +187,7 @@ pub fn read_place_builder_configuration() -> PlaceBuilder {
 fn build_template(yaml_value: &yaml_rust::Yaml) -> Result<Template, Error> {
     let addr_template = yaml_value
         .as_str()
-        .ok_or_else(|| format_err!("no value to build template"))?;
+        .ok_or_else(|| anyhow!("no value to build template"))?;
 
     Ok(Template::new(addr_template))
 }

--- a/tests/opencage_tests.rs
+++ b/tests/opencage_tests.rs
@@ -1,18 +1,16 @@
 use address_formatter::{Formatter, Place, PlaceBuilder};
 use failure::{format_err, Error};
-use include_dir::{include_dir, include_dir_impl};
+use include_dir::include_dir;
 use yaml_rust::{Yaml, YamlLoader};
 
 #[test]
 pub fn opencage_tests() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    let tests_dir = include_dir!("./address-formatting/testcases/countries");
 
     let formatter = Formatter::default();
     let places_builder = PlaceBuilder::default();
-    let errors: Vec<_> = tests_dir
+    let errors: Vec<_> = include_dir!("./address-formatting/testcases/countries")
         .files()
-        .iter()
         .filter_map(|f| {
             f.contents_utf8().map(|s| {
                 (

--- a/tests/opencage_tests.rs
+++ b/tests/opencage_tests.rs
@@ -1,5 +1,5 @@
 use address_formatter::{Formatter, Place, PlaceBuilder};
-use failure::{format_err, Error};
+use anyhow::{anyhow, Context, Error};
 use include_dir::include_dir;
 use yaml_rust::{Yaml, YamlLoader};
 
@@ -56,19 +56,19 @@ fn run_test(
 
     let expected = yaml["expected"]
         .as_str()
-        .ok_or_else(|| format_err!("no expected value provided for file {}", file_name))?;
+        .context("no expected value provided for file")?;
 
     let addr = read_addr(
         yaml["components"]
             .as_hash()
-            .ok_or_else(|| format_err!("no component value provided {}", file_name))?,
+            .context("no component value provided")?,
         places_builder,
     )?;
 
     let formated_value = formatter.format(addr)?;
 
     if formated_value != expected {
-        Err(format_err!(
+        Err(anyhow!(
             r#"
 ====================================
 for file {}, test "{}"

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -81,7 +81,7 @@ pub fn address_builder() {
         ("state", "French Polynesia"),
     ];
 
-    let addr = addr_builder.build_place(data.into_iter().map(|(k, v)| (k.clone(), v.to_string())));
+    let addr = addr_builder.build_place(data.into_iter().map(|(k, v)| (k, v.to_string())));
 
     assert_eq!(
         formatter.format(addr).unwrap(),


### PR DESCRIPTION
With the help of `cargo update`, `cargo audit` and `cargo outdated`, sanitize dependencies. This is part of an effort to cleanup dependencies of mimirsbrunn that should reach the main repo soon :smile: 

 - trivial updates on dependencies when possible
 - `handlebars` is 4.1 now, we were based on 2.0-beta
 - `failure` is not maintained, I replaced it with the closely equivalent `anyhow`